### PR TITLE
feat: Card - QR Code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-  runtimeOnly 'com.h2database:h2'
+	implementation 'com.google.zxing:core:3.5.1'
+	implementation 'com.google.zxing:javase:3.5.1'
+	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/devcard/devcard/card/controller/QrController.java
+++ b/src/main/java/com/devcard/devcard/card/controller/QrController.java
@@ -1,0 +1,31 @@
+package com.devcard.devcard.card.controller;
+
+import com.devcard.devcard.card.dto.QrResponseDto;
+import com.devcard.devcard.card.service.QrServiceImpl;
+import com.google.zxing.WriterException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+public class QrController {
+
+    private final QrServiceImpl qrServiceImpl;
+
+    @Autowired
+    public QrController(QrServiceImpl qrServiceImpl) {
+        this.qrServiceImpl = qrServiceImpl;
+    }
+
+    @GetMapping("/cards/{card_id}/qrcode")
+    public ResponseEntity<QrResponseDto> createQR(@PathVariable (name = "card_id") Long cardId) throws IOException, WriterException {
+        String qrUrl = qrServiceImpl.createQr(cardId);
+
+        return ResponseEntity.ok()
+                .body(new QrResponseDto(qrUrl));
+    }
+}

--- a/src/main/java/com/devcard/devcard/card/dto/QrResponseDto.java
+++ b/src/main/java/com/devcard/devcard/card/dto/QrResponseDto.java
@@ -1,0 +1,6 @@
+package com.devcard.devcard.card.dto;
+
+public record QrResponseDto(
+        String qrcode_url
+) {
+}

--- a/src/main/java/com/devcard/devcard/card/service/QrService.java
+++ b/src/main/java/com/devcard/devcard/card/service/QrService.java
@@ -1,0 +1,10 @@
+package com.devcard.devcard.card.service;
+
+import com.google.zxing.WriterException;
+
+import java.io.IOException;
+
+public interface QrService {
+
+    Object createQr(Long cardId) throws WriterException, IOException;
+}

--- a/src/main/java/com/devcard/devcard/card/service/QrServiceImpl.java
+++ b/src/main/java/com/devcard/devcard/card/service/QrServiceImpl.java
@@ -1,0 +1,51 @@
+package com.devcard.devcard.card.service;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.MultiFormatWriter;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+public class QrServiceImpl implements QrService{
+
+    private static final int QR_SIZE_WIDTH = 200;
+    private static final int QR_SIZE_HEIGHT = 200;
+    private static final String DOMAIN_URI = "http://localhost:8080/";
+    private final String QR_CODE_DIRECTORY = "src/main/resources/static/qrcodes/";
+
+    /**
+     * @param cardId QR로 만들 명함 ID
+     * @return QR 코드 IMAGE 파일 이름만 반환
+     */
+    @Override
+    public String createQr(Long cardId) throws WriterException, IOException {
+
+        // QR URL - QR 코드 정보 URL
+        String url = DOMAIN_URI + "cards/" + cardId;
+
+        // QR Code - BitMatrix: qr code 정보 생성
+        BitMatrix bitMatrix = new MultiFormatWriter().encode(url, BarcodeFormat.QR_CODE, QR_SIZE_WIDTH, QR_SIZE_HEIGHT);
+
+        // Setting QR Image File Name, Path
+        String qrFileName = "card_id_" + cardId + ".png";
+        Path qrPath = Paths.get(QR_CODE_DIRECTORY + qrFileName);
+
+        // Save QR
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();)
+        {
+            MatrixToImageWriter.writeToStream(bitMatrix, "png", out);
+            Files.createDirectories(qrPath.getParent()); // 디렉토리 없는 경우 생성
+            Files.write(qrPath, out.toByteArray());
+        }
+
+        return DOMAIN_URI + "qrcodes/" + qrFileName;
+    }
+}


### PR DESCRIPTION
명함의 QR Code  기능 추가하였습니다. 
API 문서에 명시된대로 아래와 같이 Response하며, 사용자의 명함을 QR로 공유하는 기능인데 QR코드를 찍으면 명함이 공유됩니다. 
현재 구현은 클라우드에 이미지를 저장하는 것이 아닌 임시로 static 폴더에 QR Code 이미지를 저장하고 이 QR Code가 저장된 url을 반환합니다.  QR Code를 찍으면 사용자의 명함정보(Json Data)이 나오도록 구현하여 추후 요구사항에 맞게 명함 자체가 공유되는 형식으로 변환하려합니다. 

``` 
Status 200 OK
{
"qrcode_url": "https://api.digitalcardservice.com/qrcode/card_id_123.png"
}
```
``` 
Status 200 OK
{
"qrcode_url": "https://localhost:8080/qrcode/card_id_123.png"
}
```
