### PR TITLE
feat: 특정 유저가 참여하고 있는 채팅방 목록을 조회하는 API 추가

### DIFF
--- a/src/main/java/com/devcard/devcard/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/devcard/devcard/chat/controller/ChatRoomController.java
@@ -42,11 +42,20 @@ public class ChatRoomController {
 
     /**
      * 모든 채팅방 목록을 조회
-     * @return 전체 채팅방 목록을 리스트 형태 반환
+     * @return 전체 채팅방 목록을 리스트 형태로 반환
      */
     @GetMapping("")
     public ResponseEntity<List<ChatRoomListResponse>> getChatRoomList() {
         return ResponseEntity.ok(chatRoomService.getChatRoomList());
+    }
+
+    /**
+     * 특정 유저가 참여하고 있는 채팅방 목록을 조회
+     * @return 해당 채팅방 목록을 리스트 형태로 반환
+     */
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<ChatRoomListResponse>> getChatRoomsByUser(@PathVariable String userId) {
+        return ResponseEntity.ok(chatRoomService.getChatRoomsByUser(userId));
     }
 
     /**

--- a/src/main/java/com/devcard/devcard/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/devcard/devcard/chat/dto/ChatRoomListResponse.java
@@ -14,7 +14,7 @@ public class ChatRoomListResponse {
         long id, List<String> participants, String lastMessage,
         LocalDateTime lastMessageTime
     ) {
-        this.id = "msg_" + id;
+        this.id = "room_" + id;
         this.participants = participants;
         this.lastMessage = lastMessage;
         this.lastMessageTime = lastMessageTime;

--- a/src/main/java/com/devcard/devcard/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/devcard/devcard/chat/repository/ChatRoomRepository.java
@@ -1,8 +1,12 @@
 package com.devcard.devcard.chat.repository;
 
 import com.devcard.devcard.chat.model.ChatRoom;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-
+    @Query("SELECT cr FROM ChatRoom cr JOIN cr.participants p WHERE p.id = :userId")
+    List<ChatRoom> findByParticipantId(@Param("userId") String userId);
 }

--- a/src/main/java/com/devcard/devcard/chat/service/ChatRoomService.java
+++ b/src/main/java/com/devcard/devcard/chat/service/ChatRoomService.java
@@ -71,6 +71,24 @@ public class ChatRoomService {
     }
 
     /**
+     * 특정 유저가 참여 중인 채팅방 목록 조회
+     * @param userId 유저 ID
+     * @return 해당 유저가 참여 중인 채팅방 목록
+     */
+    @Transactional(readOnly = true)
+    public List<ChatRoomListResponse> getChatRoomsByUser(String userId) {
+        List<ChatRoom> userChatRooms = chatRoomRepository.findByParticipantId(userId);
+
+        // 각 채팅방 정보를 ChatRoomListResponse로 변환하여 반환
+        return userChatRooms.stream().map(chatRoom -> new ChatRoomListResponse(
+            chatRoom.getId(),
+            chatRoom.getParticipantsName(),
+            chatRoom.getLastMessage(),
+            chatRoom.getLastMessageTime()
+        )).collect(Collectors.toList());
+    }
+
+    /**
      * 특정 채팅방의 세부 정보 조회
      * @param chatId 채팅방 ID
      * @return 채팅방 세부 정보

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,29 +1,29 @@
 -- 채팅 관련 data.sql (line 1~25)
 -- 예시 명함 데이터
 INSERT INTO chat_user (id, name, company, position, email, phone, timestamp) VALUES
-                                                                                 (1, '라이언', 'kakao', 'Software Engineer', 'ryan@kakao.com', '123-123', CURRENT_TIMESTAMP),
-                                                                                 (2, '죠르디', 'kakao', 'Product Manager', 'jordy@kakao.com', '456-456', CURRENT_TIMESTAMP),
-                                                                                 (3, '어피치', 'kakao', 'Backend Developer', 'apeach@kakao.com', '789-789', CURRENT_TIMESTAMP);
+    (1, '라이언', 'kakao', 'Software Engineer', 'ryan@kakao.com', '123-123', CURRENT_TIMESTAMP),
+    (2, '죠르디', 'kakao', 'Product Manager', 'jordy@kakao.com', '456-456', CURRENT_TIMESTAMP),
+    (3, '어피치', 'kakao', 'Backend Developer', 'apeach@kakao.com', '789-789', CURRENT_TIMESTAMP);
 
 -- 예시 채팅방 데이터
 INSERT INTO chat_room (created_at, last_message, last_message_time) VALUES
-                                                                        (CURRENT_TIMESTAMP, 'Hello, world!', CURRENT_TIMESTAMP),
-                                                                        (CURRENT_TIMESTAMP, '새로운 채팅방 메시지~', CURRENT_TIMESTAMP);
+    (CURRENT_TIMESTAMP, 'Hello, world!', CURRENT_TIMESTAMP),
+    (CURRENT_TIMESTAMP, '새로운 채팅방 메시지~', CURRENT_TIMESTAMP);
 
 -- 예시 채팅 메시지 데이터
 INSERT INTO chat_message (content, sender, timestamp, chat_room_id) VALUES
-                                                                        ('안녕하세요', '라이언', CURRENT_TIMESTAMP, 1),
-                                                                        ('새로운 채팅방 메시지~', '어피치', CURRENT_TIMESTAMP, 2),
-                                                                        ('Hello, world!', '죠르디', CURRENT_TIMESTAMP + 0.1, 1);
+    ('안녕하세요', '라이언', CURRENT_TIMESTAMP, 1),
+    ('새로운 채팅방 메시지~', '어피치', CURRENT_TIMESTAMP, 2),
+    ('Hello, world!', '죠르디', CURRENT_TIMESTAMP + 0.1, 1);
 
 -- 예시 채팅방 참가자 데이터
 INSERT INTO chat_room_participants (chat_room_id, participants_id) VALUES
-                                                                       (1, 1),
-                                                                       (1, 2),
-                                                                       (2, 1),
-                                                                       (2, 3);
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 3);
 
 -- 명함(Card) 테이블에 예시 데이터 추가
 INSERT INTO card (github_id, name, company, position, email, phone, profile_picture, bio) VALUES
-                                                                                              ('hong-gildong', '어피치', 'DevCompany', '백엔드 개발자', 'hong@example.com', '010-1234-5678', 'profile.jpg', '열정적인 개발자입니다.'),
-                                                                                              ('hong-gildong', '춘식이', 'kakaoCompany', '백엔드 주니어 개발자', 'chun@kakaoTech.com', '010-7894-456', 'profile.jpg', '소통하는 개발자입니다.');
+    ('hong-gildong', '어피치', 'DevCompany', '백엔드 개발자', 'hong@example.com', '010-1234-5678', 'profile.jpg', '열정적인 개발자입니다.'),
+    ('hong-gildong', '춘식이', 'kakaoCompany', '백엔드 주니어 개발자', 'chun@kakaoTech.com', '010-7894-456', 'profile.jpg', '소통하는 개발자입니다.');


### PR DESCRIPTION
### 변경점
- `ChatRoomController` - 해당 API의 엔드포인트 `"/user/{userId}"` 추가
- `ChatRoomService` - 특정 유저가 참여 중인 채팅방을 반환하는 비즈니스 로직 `getChatRoomsByUser` 추가
- `ChatRoomRepository` - 쿼리를 통해 db에서 유저가 참여한 채팅방을 찾는 `findByParticipantId` 메서드 추가
- API 명세 준수를 위해 `ChatRoomListResponse`의 prefix를 수정