### PR TITLE
Member DTO 분리 및 초기 데이터 수정

### DIFF
--- a/src/main/java/com/devcard/devcard/auth/config/SecurityConfig.java
+++ b/src/main/java/com/devcard/devcard/auth/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
                             "/",
                             "/home",
                             "/login",
-                            "/cards/**",
+                            "/cards",
+                            "/cards/{id}",
                             "/oauth2/**",
                             "/css/**",
                             "/js/**",
@@ -39,7 +40,6 @@ public class SecurityConfig {
                 })
                 .oauth2Login(oauth -> oauth
                         .loginPage("/login") // 커스텀 로그인 페이지 경로 설정
-//                        .defaultSuccessUrl("/home") // 로그인 성공 후 이동할 경로
                         .defaultSuccessUrl("/redirect") // 로그인 성공 후 이동할 경로
                         .userInfoEndpoint(userInfo ->
                                 userInfo.userService(oauthService)

--- a/src/main/java/com/devcard/devcard/auth/controller/OauthController.java
+++ b/src/main/java/com/devcard/devcard/auth/controller/OauthController.java
@@ -1,9 +1,11 @@
 package com.devcard.devcard.auth.controller;
 
 import com.devcard.devcard.auth.entity.Member;
+import com.devcard.devcard.auth.model.OauthMemberDetails;
 import com.devcard.devcard.auth.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,14 +20,8 @@ public class OauthController {
     private MemberRepository memberRepository;
 
     @PostMapping("/register")
-    public ResponseEntity<Map<String, Object>> registerUser(Authentication authentication) {
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        String githubId = String.valueOf(oAuth2User.getAttributes().get("id"));
-
-        System.out.println("깃허브 아이디: " + githubId);
-
-        // GitHub ID로 사용자를 찾아서 등록 여부 확인
-        Member member = memberRepository.findByGithubId(githubId);
+    public ResponseEntity<Map<String, Object>> registerUser(@AuthenticationPrincipal OauthMemberDetails oauthMemberDetails) {
+        Member member = oauthMemberDetails.getMember();
         boolean isRegistered = (member != null);
 
         Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/devcard/devcard/auth/dto/MemberRequestDto.java
+++ b/src/main/java/com/devcard/devcard/auth/dto/MemberRequestDto.java
@@ -1,0 +1,29 @@
+package com.devcard.devcard.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class MemberRequestDto {
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "유효한 이메일 주소를 입력하세요.")
+    private String email;
+
+    @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+    private String nickname;
+
+    private String profileImg;
+
+    public MemberRequestDto() {
+    }
+
+    public MemberRequestDto(String email, String nickname, String profileImg) {
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImg = profileImg;
+    }
+
+    public String getEmail() { return email; }
+    public String getNickname() { return nickname; }
+    public String getProfileImg() { return profileImg; }
+}

--- a/src/main/java/com/devcard/devcard/auth/dto/MemberResponseDto.java
+++ b/src/main/java/com/devcard/devcard/auth/dto/MemberResponseDto.java
@@ -1,0 +1,69 @@
+package com.devcard.devcard.auth.dto;
+
+import com.devcard.devcard.auth.entity.Member;
+
+import java.sql.Timestamp;
+
+public class MemberResponseDto {
+
+    private Long id;
+    private String githubId;
+    private String email;
+    private String profileImg;
+    private String username;
+    private String nickname;
+    private Timestamp createDate;
+
+    public MemberResponseDto() {
+    }
+
+    public MemberResponseDto(Long id, String githubId, String email, String profileImg, String username, String nickname, Timestamp createDate) {
+        this.id = id;
+        this.githubId = githubId;
+        this.email = email;
+        this.profileImg = profileImg;
+        this.username = username;
+        this.nickname = nickname;
+        this.createDate = createDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getGithubId() {
+        return githubId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getProfileImg() {
+        return profileImg;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public Timestamp getCreateDate() {
+        return createDate;
+    }
+
+    public static MemberResponseDto fromEntity(Member member) {
+        return new MemberResponseDto(
+                member.getId(),
+                member.getGithubId(),
+                member.getEmail(),
+                member.getProfileImg(),
+                member.getUsername(),
+                member.getNickname(),
+                member.getCreateDate()
+        );
+    }
+}

--- a/src/main/java/com/devcard/devcard/auth/entity/Member.java
+++ b/src/main/java/com/devcard/devcard/auth/entity/Member.java
@@ -1,10 +1,13 @@
 package com.devcard.devcard.auth.entity;
 
+import com.devcard.devcard.auth.dto.MemberRequestDto;
+import com.devcard.devcard.card.entity.Card;
 import jakarta.persistence.Entity;
 import org.hibernate.annotations.CreationTimestamp;
 
 import jakarta.persistence.*;
 import java.sql.Timestamp;
+import java.util.Map;
 
 @Entity
 @Table(name = "member")
@@ -24,6 +27,9 @@ public class Member {
     @CreationTimestamp
     private Timestamp createDate;
 
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    private Card card;
+
     public Member() {
     }
 
@@ -36,6 +42,21 @@ public class Member {
         this.role = role;
         this.createDate = createDate;
     }
+
+    public void updateFromAttributes(Map<String, Object> attributes) {
+        this.email = (String) attributes.get("email");
+        this.profileImg = (String) attributes.get("avatar_url");
+        this.username = (String) attributes.get("name");
+        this.nickname = (String) attributes.get("login");
+    }
+
+    public void updateFromDto(MemberRequestDto dto) {
+        if (dto.getEmail() != null) this.email = dto.getEmail();
+        if (dto.getNickname() != null) this.nickname = dto.getNickname();
+        if (dto.getProfileImg() != null) this.profileImg = dto.getProfileImg();
+    }
+
+
 
     public Long getId() {
         return id;

--- a/src/main/java/com/devcard/devcard/auth/model/OauthMemberDetails.java
+++ b/src/main/java/com/devcard/devcard/auth/model/OauthMemberDetails.java
@@ -40,4 +40,6 @@ public class OauthMemberDetails implements OAuth2User {
     public String getName() {
         return member.getId()+"";
     }
+
+    public Member getMember() { return member; }
 }

--- a/src/main/java/com/devcard/devcard/auth/repository/MemberRepository.java
+++ b/src/main/java/com/devcard/devcard/auth/repository/MemberRepository.java
@@ -3,6 +3,6 @@ package com.devcard.devcard.auth.repository;
 import com.devcard.devcard.auth.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Integer> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByGithubId(String githubId);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -24,7 +24,7 @@ INSERT INTO chat_room_participants (chat_room_id, participants_member_id) VALUES
     (2, 1),
     (2, 3);
 
--- 명함(Card) 테이블에 예시 데이터 추가
-INSERT INTO card (github_id, name, company, position, email, phone, profile_picture, bio) VALUES
-    ('hong-gildong', '어피치', 'DevCompany', '백엔드 개발자', 'hong@example.com', '010-1234-5678', 'profile.jpg', '열정적인 개발자입니다.'),
-    ('hong-gildong', '춘식이', 'kakaoCompany', '백엔드 주니어 개발자', 'chun@kakaoTech.com', '010-7894-456', 'profile.jpg', '소통하는 개발자입니다.');
+-- Card 테이블에 데이터 삽입
+INSERT INTO card (member_id, company, position, phone, bio) VALUES
+    (1, 'DevCompany', '백엔드 개발자', '010-1234-5678', '열정적인 개발자입니다.'),
+    (2, 'kakaoCompany', '백엔드 주니어 개발자', '010-7894-456', '소통하는 개발자입니다.');


### PR DESCRIPTION
- Member 및 Card 엔티티 변경 사항에 맞게 초기 데이터 수정
- MemberRequestDto를 기반으로 엔티티 필드 업데이트 가능하도록 메서드 추가
- Member 엔티티의 ID 타입 변경에 따라 JpaRepository 제네릭 타입 수정
- @AuthenticationPrincipal로 OauthMemberDetails를 받아 인증 정보 활용
- MemberRepository 의존성 제거 및 코드 간소화
- loadUser 메서드에서 OauthMemberDetails를 반환하여 Member 정보를 인증에 포함
- 기존 회원의 정보 업데이트 로직 추가